### PR TITLE
Step4 PR : 같은 사용자가 동일한 특강에 대해 신청 성공하지 못하도록 개선

### DIFF
--- a/src/main/java/io/hhplus/course_registration/entity/RegisterCourseHistory.java
+++ b/src/main/java/io/hhplus/course_registration/entity/RegisterCourseHistory.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"member_id", "course_info_id"})})
 public class RegisterCourseHistory extends EntityTimestamp {
 
     public RegisterCourseHistory(Member member, CourseInfo courseInfo) {

--- a/src/main/java/io/hhplus/course_registration/repository/RegisterCourseHistoryRepository.java
+++ b/src/main/java/io/hhplus/course_registration/repository/RegisterCourseHistoryRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface RegisterCourseHistoryRepository extends JpaRepository<RegisterCourseHistory, Long> {
     List<RegisterCourseHistory> findAllByMemberMemberId(Long memberId);
     List<RegisterCourseHistory> findAllByCourseInfoCourseInfoId(Long courseInfoId);
+    Boolean existsByCourseInfoCourseInfoIdAndMemberMemberId(Long courseInfoId, Long memberId);
 }

--- a/src/main/java/io/hhplus/course_registration/service/CourseService.java
+++ b/src/main/java/io/hhplus/course_registration/service/CourseService.java
@@ -40,6 +40,10 @@ public class CourseService {
         Member member = memberRepository.findById(req.memberId()).orElseThrow(
                 () -> new IllegalArgumentException("해당 유저를 찾을 수 없습니다.")
         );
+        Boolean existsRegisterCourseHistory = registerCourseHistoryRepository.existsByCourseInfoCourseInfoIdAndMemberMemberId(courseInfo.getCourseInfoId(), member.getMemberId());
+        if (existsRegisterCourseHistory) {
+            throw new IllegalArgumentException("동일한 강의는 한번만 신청이 가능합니다.");
+        }
         CourseEnrollment courseEnrollment = courseEnrollmentRepository.findByCourseInfoCourseInfoId(courseInfo.getCourseInfoId());
         if (courseEnrollment.getEnrollment() >= courseInfo.getCapacity()) {
             throw new IllegalArgumentException("강의 최대 수강 인원은 30명까지 입니다.");

--- a/src/test/java/io/hhplus/course_registration/RegisterCourseIntegrationTest.java
+++ b/src/test/java/io/hhplus/course_registration/RegisterCourseIntegrationTest.java
@@ -5,11 +5,13 @@ import io.hhplus.course_registration.entity.*;
 import io.hhplus.course_registration.entity.enums.CourseStatus;
 import io.hhplus.course_registration.repository.*;
 import io.hhplus.course_registration.service.CourseService;
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -195,8 +197,8 @@ public class RegisterCourseIntegrationTest {
         int threadCount = 10;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch countDownLatch = new CountDownLatch(threadCount);
-        executorService.execute(() -> {
-            for (int i = 0; i < threadCount; i++) {
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
                 CourseDto.RegisterCourseRequest req = new CourseDto.RegisterCourseRequest(courseInfoId, memberId);
                 try {
                     courseService.registerCourse(req);
@@ -205,8 +207,8 @@ public class RegisterCourseIntegrationTest {
                 } finally {
                     countDownLatch.countDown();
                 }
-            }
-        });
+            });
+        }
         countDownLatch.await();
 
         List<RegisterCourseHistory> resultList = registerCourseHistoryRepository.findAllByCourseInfoCourseInfoId(courseInfoId);


### PR DESCRIPTION
같은 사용자가 동일한 특강에 대해 신청 성공하지 못하도록 개선 (cb6c7e7)

단위 테스트 수정 및 추가 (121a26c)

통합 테스트 추가 (b9173d6)

테스트 시 멀티쓰레드로 테스트한게 아닌 단일쓰레드로 진행되서 테스트가 통과되었습니다..
멀티쓰레드 시 테스트 실패가 났습니다.

RegisterCourseHistory 테이블에서 unique 조건을 추가하여 데이터베이스 레벨에서 등록이 안되도록 수정했습니다.
이에 따른 서비스 비즈니스 로직 변경, 테스트 멀티쓰레드로 변경 하였습니다. (6d0b025)

unique 조건을 추가하지 않고 하려면
1. RegisterCourseHistory 에서 auto increment를 사용하는 개별 ID말고 member_id와 course_info_id를 복합키로 사용해 여기에 비관적 락을 거는것
2. auto increment를 사용하는 id가 아닌 직접 부여해주는 id를 만들어(member_id와 course_info_id를 조합한다든지) register_course_history_id, member_id, course_info_id 모두 비관적 락이 걸리게 하는것
이러한 방식으로 방향을 잡는게 맞을까요?